### PR TITLE
Fix command queue reference

### DIFF
--- a/V_COVA/alt.py
+++ b/V_COVA/alt.py
@@ -229,7 +229,7 @@ class ActivacionVoz(threading.Thread):
     def extract_command_number(self, response):
         match = re.search(r"ejecutando comando\s*(\d+)", response.lower())
         if match:
-            self.queue.put(int(match.group(1)))
+            self.command_queue.put(int(match.group(1)))
             return int(match.group(1))
         return None
     


### PR DESCRIPTION
## Summary
- route extracted commands to `command_queue`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856fd5e08988321b0c9f584528888af