### PR TITLE
Fix units in coordinate comments

### DIFF
--- a/UR.py
+++ b/UR.py
@@ -228,7 +228,7 @@ def move_robot(xtransfn, ytransfn, ofzn, control, receive):
         Verifica si un punto está dentro del alcance del UR5-e.
         
         Parámetro:
-        point (tuple): Una tupla con las coordenadas (x, y, z) del punto en milímetros.
+        point (tuple): Una tupla con las coordenadas (x, y, z) del punto en metros.
         
         Retorna:
         bool: True si el punto está dentro del alcance, False de lo contrario.

--- a/V1.0/Scripts/demo_model.py
+++ b/V1.0/Scripts/demo_model.py
@@ -222,7 +222,7 @@ def move_robot(xtransfn, ytransfn, ofzn, control, receive):
         Verifica si un punto está dentro del alcance del UR5-e.
         
         Parámetro:
-        point (tuple): Una tupla con las coordenadas (x, y, z) del punto en milímetros.
+        point (tuple): Una tupla con las coordenadas (x, y, z) del punto en metros.
         
         Retorna:
         bool: True si el punto está dentro del alcance, False de lo contrario.

--- a/V1.0/Scripts/jp_hand.py
+++ b/V1.0/Scripts/jp_hand.py
@@ -216,7 +216,7 @@ def move_robot(xtransfn, ytransfn, ofzn, control, receive):
         Verifica si un punto está dentro del alcance del UR5-e.
         
         Parámetro:
-        point (tuple): Una tupla con las coordenadas (x, y, z) del punto en milímetros.
+        point (tuple): Una tupla con las coordenadas (x, y, z) del punto en metros.
         
         Retorna:
         bool: True si el punto está dentro del alcance, False de lo contrario.

--- a/V1.0/Scripts/pick_it.py
+++ b/V1.0/Scripts/pick_it.py
@@ -223,7 +223,7 @@ def move_robot(xtransfn, ytransfn, ofzn, control, receive):
         Verifica si un punto está dentro del alcance del UR5-e.
         
         Parámetro:
-        point (tuple): Una tupla con las coordenadas (x, y, z) del punto en milímetros.
+        point (tuple): Una tupla con las coordenadas (x, y, z) del punto en metros.
         
         Retorna:
         bool: True si el punto está dentro del alcance, False de lo contrario.

--- a/V1.0/Scripts/workarea.py
+++ b/V1.0/Scripts/workarea.py
@@ -33,7 +33,7 @@ def move_robot(xtransfn, ytransfn, ofzn, control, receive):
         Verifica si un punto está dentro del alcance del UR5-e.
         
         Parámetro:
-        point (tuple): Una tupla con las coordenadas (x, y, z) del punto en milímetros.
+        point (tuple): Una tupla con las coordenadas (x, y, z) del punto en metros.
         
         Retorna:
         bool: True si el punto está dentro del alcance, False de lo contrario.


### PR DESCRIPTION
## Summary
- clarify comments that coordinates are given in meters

## Testing
- `git ls-files '*.py' | tr '\n' '\0' | xargs -0 python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_6856fd69a3f48321b21760f53054db2a