### PR TITLE
Add pytest utilities and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ Para que todo funcione correctamente, instala los siguientes paquetes:
 sudo apt-get install portaudio19-dev
 ```
 
+## ✅ **Tests**
+
+Para verificar el correcto funcionamiento de las funciones básicas se incluye una suite de
+pruebas con `pytest`. Desde la raíz del proyecto ejecuta:
+
+```bash
+pytest
+```
+
 ---
 
 ## 🔗 **Referencias adicionales**

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,38 @@
+import sys
+import os
+import types
+import math
+
+# Ensure repository root is on sys.path
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+# Stub out heavy optional dependencies before importing UR
+# Create simple placeholder modules for heavy dependencies
+for mod in ["pyrealsense2", "cv2", "rtde_control", "rtde_receive", "rtde_io"]:
+    sys.modules.setdefault(mod, types.ModuleType(mod))
+
+# "activacion_voz" must provide ActivacionVoz attribute
+sys.modules.setdefault("activacion_voz", types.SimpleNamespace(ActivacionVoz=lambda *a, **k: None))
+# ultralytics.YOLO is used but not needed for these tests
+sys.modules.setdefault("ultralytics", types.SimpleNamespace(YOLO=lambda *a, **k: None))
+
+from UR import mapValue, transformCoordinates
+
+
+def test_map_value_scaling():
+    assert mapValue(50, 0, 100, 0, 1) == 0.5
+    assert mapValue(25, 0, 100, -1, 1) == -0.5
+
+
+def test_transform_coordinates_basic():
+    x, y = transformCoordinates(1, 0, 0, 0, 0)
+    assert math.isclose(x, 0.0, abs_tol=1e-6)
+    assert math.isclose(y, -1.0, abs_tol=1e-6)
+
+    x, y = transformCoordinates(1, 0, 1, 2, 0)
+    assert math.isclose(x, 1.0, abs_tol=1e-6)
+    assert math.isclose(y, 1.0, abs_tol=1e-6)
+
+    x, y = transformCoordinates(1, 0, 0, 0, math.pi / 2)
+    assert math.isclose(x, 1.0, abs_tol=1e-6)
+    assert math.isclose(y, 0.0, abs_tol=1e-6)


### PR DESCRIPTION
## Summary
- add pytest section to README for running tests
- provide basic pytest tests for `mapValue` and `transformCoordinates`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856fd74d43083218f62bf1c950ceb2a